### PR TITLE
Fix bug, wrong parameter `header_list`

### DIFF
--- a/bottle_werkzeug.py
+++ b/bottle_werkzeug.py
@@ -51,10 +51,12 @@ class WerkzeugPlugin(object):
         :class:`werkzeug.Request`. It basically turns Bottle into Flask. """
 
     name = 'werkzeug'
+    api = 2
 
     def __init__(self, evalex=False, request_class=werkzeug.Request,
-                       debugger_class=WerkzeugDebugger):
+                       response_class=werkzeug.Response, debugger_class=WerkzeugDebugger):
         self.request_class = request_class
+        self.response_class = response_class
         self.debugger_class = debugger_class
         self.evalex=evalex
         self.app = None
@@ -69,6 +71,7 @@ class WerkzeugPlugin(object):
         def wrapper(*a, **ka):
             environ = bottle.request.environ
             bottle.local.werkzeug_request = self.request_class(environ)
+            bottle.local.werkzeug_response = self.response_class(environ)
             try:
                 rv = callback(*a, **ka)
             except werkzeug.exceptions.HTTPException:
@@ -83,6 +86,12 @@ class WerkzeugPlugin(object):
         ''' Return a local proxy to the current :class:`werkzeug.Request`
             instance.'''
         return werkzeug.LocalProxy(lambda: bottle.local.werkzeug_request)
+
+    @property
+    def response(self):
+        ''' Return a local proxy to the current :class:`werkzeug.Response`
+            instance.'''
+        return werkzeug.LocalProxy(lambda: bottle.local.werkzeug_response)
 
     def __getattr__(self, name):
         ''' Convenient access to werkzeug module contents. '''

--- a/bottle_werkzeug.py
+++ b/bottle_werkzeug.py
@@ -44,7 +44,7 @@ class WerkzeugDebugger(DebuggedApplication):
             return DebuggedApplication.__call__(self, environ, start_response)
         return self.app(environ, start_response)
 
-            
+
 class WerkzeugPlugin(object):
     """ This plugin adds support for :class:`werkzeug.Response`, all kinds of
         :module:`werkzeug.exceptions` and provides a thread-local instance of
@@ -74,7 +74,7 @@ class WerkzeugPlugin(object):
             except werkzeug.exceptions.HTTPException:
                 rv = sys.exc_info()[1]
             if isinstance(rv, werkzeug.BaseResponse):
-                rv = bottle.HTTPResponse(rv.iter_encoded(), rv.status_code, rv.header_list)
+                rv = bottle.HTTPResponse(rv.iter_encoded(), rv.status_code, rv.headers)
             return rv
         return wrapper
 
@@ -83,7 +83,7 @@ class WerkzeugPlugin(object):
         ''' Return a local proxy to the current :class:`werkzeug.Request`
             instance.'''
         return werkzeug.LocalProxy(lambda: bottle.local.werkzeug_request)
-    
+
     def __getattr__(self, name):
         ''' Convenient access to werkzeug module contents. '''
         return getattr(werkzeug, name)

--- a/test.py
+++ b/test.py
@@ -19,17 +19,15 @@ class WerkzeugTest(unittest.TestCase):
         self.app({'PATH_INFO':'/', 'REQUEST_METHOD':'GET',
                   'HTTP_ACCEPT_LANGUAGE': 'de, en;q=0.7'}, lambda x, y: None)
 
-
     def test_response_obj(self):
         response_plugin = self.plugin.response
-        response_source= bw.Response()
+        response_source = bw.Response()
         @self.app.get('/')
         def test():
             self.assertTrue(hasattr(response_plugin, 'headers'))
             self.assertFalse(hasattr(response_plugin, 'header_list'))
             self.assertTrue(hasattr(response_source, 'headers'))
             self.assertFalse(hasattr(response_source, 'header_list'))
-
             return repr(self.plugin.response)
         self.app({'PATH_INFO':'/', 'REQUEST_METHOD':'GET',
                   'HTTP_ACCEPT_LANGUAGE': 'de, en;q=0.7'}, lambda x, y: None)

--- a/test.py
+++ b/test.py
@@ -19,5 +19,22 @@ class WerkzeugTest(unittest.TestCase):
         self.app({'PATH_INFO':'/', 'REQUEST_METHOD':'GET',
                   'HTTP_ACCEPT_LANGUAGE': 'de, en;q=0.7'}, lambda x, y: None)
 
+
+    def test_response_obj(self):
+        response_plugin = self.plugin.response
+        response_source= bw.Response()
+        @self.app.get('/')
+        def test():
+            self.assertTrue(hasattr(response_plugin, 'headers'))
+            self.assertFalse(hasattr(response_plugin, 'header_list'))
+            self.assertTrue(hasattr(response_source, 'headers'))
+            self.assertFalse(hasattr(response_source, 'header_list'))
+
+            return repr(self.plugin.response)
+        self.app({'PATH_INFO':'/', 'REQUEST_METHOD':'GET',
+                  'HTTP_ACCEPT_LANGUAGE': 'de, en;q=0.7'}, lambda x, y: None)
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
this bug will leads a `AttributeError` :

```
AttributeError: 'Response' object has no attribute 'header_list'
```

when use the `werkzeug.Response` instance and add headers to it:

```
resp = werkzeug.Response(mimetype='application/vnd.ms-excel')
resp.headers['Content-Disposition'] = ('attachment;filename="somename")
# save file into resp.stream
return resp
```

according to the `werkzeug.BaseResponse`:

```
def __init__(self, response=None, status=None, headers=None,
             mimetype=None, content_type=None, direct_passthrough=False):
    if isinstance(headers, Headers):
        self.headers = headers
....
```

so it should be `headers`.
